### PR TITLE
Added option to disable dmg cleanup

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,6 @@
 
 - name: Cleanup
   file:
-    state: "absent"
+    state: "{{ item.dmg_stat | default('absent') }}"
     path: "{{ dmg_path }}/{{ item.name }}.dmg"
   with_items: "{{ dmgs }}"


### PR DESCRIPTION
I wanted an option to invalidate deletion of dmg file, so I added it.
Since it downloads every time it deletes a file, it takes time to action.

example
```
- hosts: localhost
  connection: local
  vars:
    dmg_path: "{{ansible_env.HOME}}/Downloads"
    dmgs:
      - {
        name: "StartNinja",
        url: "https://www.macupdate.com/download/41692/StartNinjaInstaller.dmg",
        force: true,
        installed_name: "no_path",
        state: "present",
        dmg_stat: "file"
      }
```